### PR TITLE
Amazon EC2 DynamoDB and Dockerized App template updates

### DIFF
--- a/Amazon EC2 DynamoDB and Dockerized App
+++ b/Amazon EC2 DynamoDB and Dockerized App
@@ -3,10 +3,10 @@ Description:
   to a public EC2 instance. The EC2 instance is configured using files from 
   github repository here - https://github.com/linuxacademy/Content-AWS-Certified-Data-Analytics---Speciality 
   This template also sets up a DynamoDB table and populates it with some data.
-Mappings:
-  RegionMap:
-    us-east-1:
-      AMI: ami-032930428bf1abbff
+Parameters:
+  LatestAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64'
 Resources:
   AccessKey:
     Type: AWS::IAM::AccessKey
@@ -162,7 +162,7 @@ Resources:
         S3Bucket: 'das-c01-data-analytics-specialty'
         S3Key: 'Lab_Joining_Enriching_Transforming_Streaming_Data_Amazon_Kinesis/create-users-dynamodb-lambda.zip'
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       Role: !GetAtt LnLambdaExecutionAndDynamoRole.Arn
       Timeout: 60
   LnPopulateDynamoDBTableInit:
@@ -192,12 +192,8 @@ Resources:
     DependsOn:
       - LnSecurityGroupWebserver
     Properties:
-      InstanceType: t3a.medium
-      ImageId:
-        Fn::FindInMap:
-        - RegionMap
-        - !Ref AWS::Region
-        - AMI
+      InstanceType: 't3a.medium'
+      ImageId: !Ref LatestAmiId
       Tags:
         - Key: Name
           Value: !Join [ '-', [!Sub '${AWS::StackName}', 'kinesis-helper-server'] ]

--- a/Amazon EC2 DynamoDB and Dockerized App
+++ b/Amazon EC2 DynamoDB and Dockerized App
@@ -105,7 +105,7 @@ Resources:
                   send(event, context, status, responseData, None)
       Handler: index.lambda_handler
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.7
+      Runtime: python3.9
       Timeout: 60
 
   InitializeVPC:


### PR DESCRIPTION
This template was using a hardcoded AMI which was an old version of Amazon Linux 2. I've adjusted that to always pull the most recent version of the image. I also updated the Python and Node runtimes, the versions originally in the template have been deprecated.